### PR TITLE
bug/18n-empty-onload 

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,13 +1,14 @@
 import i18n from 'i18next';
 import Backend from 'i18next-xhr-backend';
-//import LanguageDetector from 'i18next-browser-languagedetector';
+import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
 i18n
   .use(Backend)
-  //.use(LanguageDetector)
+  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    lng: 'de',
     fallbackLng: 'de',
     debug: true,
     transSupportBasicHtmlNodes: true,
@@ -17,7 +18,7 @@ i18n
     },
     react: {
       wait: true,
-    },
+    }
   });
 
 export default i18n;

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,0 +1,3 @@
+{
+  "title" : "print4health"
+}

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,0 +1,3 @@
+{
+  "title" : "print4health"
+}


### PR DESCRIPTION
fixed bug where no translations where detected when language detector is not loaded. 
added default `lng: 'de'` and tested with multiple browser locales. 